### PR TITLE
Allow attachment URL

### DIFF
--- a/django_app/escrutinio_social/settings.py
+++ b/django_app/escrutinio_social/settings.py
@@ -324,7 +324,7 @@ IMAPS = json.loads(os.getenv("IMAPS", "[]"))
 SUMMERNOTE_THEME = 'lite'
 SUMMERNOTE_CONFIG = {
     # You can disable attachment feature.
-    'disable_attachment': True,
+    'disable_attachment': False,
 }
 
 


### PR DESCRIPTION
fixes #5

Summernote requires the attachments to be enable to allow the failing URL
I'mnot sure if we need attachments

