### PR TITLE
Update dependencies for Django 4.2

### DIFF
--- a/django_app/adjuntos/views/reporte_problema_create.py
+++ b/django_app/adjuntos/views/reporte_problema_create.py
@@ -11,6 +11,14 @@ from adjuntos.models import Attachment, Identificacion
 from problemas.models import Problema
 from problemas.forms import IdentificacionDeProblemaForm
 
+
+def is_ajax(request):
+    """Replaces deprecated Django 3.x function.
+
+    https://docs.djangoproject.com/en/4.1/releases/3.1/#id2
+    """
+    return request.headers.get('x-requested-with') == 'XMLHttpRequest'
+
 logger = structlog.get_logger(__name__)
 
 class ReporteDeProblemaCreateView(FormView):
@@ -32,7 +40,7 @@ class ReporteDeProblemaCreateView(FormView):
         # una vez desde el POST ajax, y otra luego de la primer redirección
         # meto este hack para que sólo cree el objeto cuando es ajax
         # y en la segunda vuelta sólo redireccion
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             fiscal = self.request.user.fiscal
             # Lo falso grabo para quedarme con la data de sus campos.
             reporte_de_problema = form.save(commit=False)

--- a/django_app/fiscales/views.py
+++ b/django_app/fiscales/views.py
@@ -63,6 +63,14 @@ from django.conf import settings
 import structlog
 
 
+def is_ajax(request):
+    """Replaces deprecated Django 3.x function.
+
+    https://docs.djangoproject.com/en/4.1/releases/3.1/#id2
+    """
+    return request.headers.get('x-requested-with') == 'XMLHttpRequest'
+
+
 NO_PERMISSION_REDIRECT = 'permission-denied'
 
 logger = structlog.get_logger(__name__)
@@ -424,7 +432,7 @@ class ReporteDeProblemaCreateView(FormView):
     def form_valid(self, form):
         # mismo hack que en la misma vista adjuntos.views.ReporteDeProblemaCreateView
         # FIX ME: no tiene tests
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             fiscal = self.request.user.fiscal
             carga = form.save(commit=False)
             carga.fiscal = fiscal

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-anymail==6.0.1
 django-autocomplete-light==3.9.7
 django-constance[database]==2.9.1
 django-excel==0.0.10
-django-extensions==2.1.7
+django-extensions==3.2.1
 django-fancy-cache==0.11.0
 django-hijack==3.4.5
 django-geojson==4.0.0
@@ -30,14 +30,15 @@ django-summernote==0.8.20.0
 django-upload-validator==1.1.6
 
 djangoql==0.17.1
-djangorestframework==3.12.4
-djangorestframework_simplejwt==4.5.0
-drf-yasg[validation]==1.20.0
+djangorestframework==3.15.2
+djangorestframework_simplejwt==5.3.1
+drf-yasg[validation]==1.21.10
 easyimap==0.7.0
 factory_boy==2.12.0
 
 git+https://github.com/mgaitan/django-admincommand.git@filefield#egg=django-admincommand
-git+https://github.com/mgaitan/django-versatileimagefield@one-dimension-resize#egg=django-versatileimagefield
+# git+https://github.com/mgaitan/django-versatileimagefield@one-dimension-resize#egg=django-versatileimagefield
+django-versatileimagefield==3.1
 
 html2text==2016.9.19
 jsonfield==2.0.2

--- a/requirements.in
+++ b/requirements.in
@@ -36,9 +36,7 @@ drf-yasg[validation]==1.21.10
 easyimap==0.7.0
 factory_boy==2.12.0
 
-git+https://github.com/mgaitan/django-admincommand.git@filefield#egg=django-admincommand
-# git+https://github.com/mgaitan/django-versatileimagefield@one-dimension-resize#egg=django-versatileimagefield
-django-versatileimagefield==3.1
+git+https://github.com/pdelboca/django-versatileimagefield@poc-auto-resize#egg=django-versatileimagefield
 
 html2text==2016.9.19
 jsonfield==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,9 @@ attrs==25.3.0
     #   jsonschema
     #   referencing
 backports-zoneinfo==0.2.1
-    # via django
+    # via
+    #   django
+    #   djangorestframework
 bleach==6.1.0
     # via django-summernote
 boto3==1.17.78
@@ -30,12 +32,6 @@ chardet==5.2.0
     # via easyimap
 charset-normalizer==3.4.3
     # via requests
-coreapi==2.3.3
-    # via drf-yasg
-coreschema==0.0.4
-    # via
-    #   coreapi
-    #   drf-yasg
 django==4.2.24
     # via
     #   -r requirements.in
@@ -43,6 +39,7 @@ django==4.2.24
     #   django-anymail
     #   django-autocomplete-light
     #   django-excel
+    #   django-extensions
     #   django-geojson
     #   django-hijack
     #   django-leaflet
@@ -52,6 +49,7 @@ django==4.2.24
     #   django-storages
     #   django-structlog
     #   django-summernote
+    #   django-versatileimagefield
     #   djangorestframework
     #   djangorestframework-simplejwt
     #   drf-yasg
@@ -70,7 +68,7 @@ django-constance[database]==2.9.1
     # via -r requirements.in
 django-excel==0.0.10
     # via -r requirements.in
-django-extensions==2.1.7
+django-extensions==3.2.1
     # via -r requirements.in
 django-fancy-cache==0.11.0
     # via -r requirements.in
@@ -98,18 +96,18 @@ django-summernote==0.8.20.0
     # via -r requirements.in
 django-upload-validator==1.1.6
     # via -r requirements.in
-django-versatileimagefield @ git+https://github.com/mgaitan/django-versatileimagefield@one-dimension-resize
+django-versatileimagefield==3.1
     # via -r requirements.in
 djangoql==0.17.1
     # via -r requirements.in
-djangorestframework==3.12.4
+djangorestframework==3.15.2
     # via
     #   -r requirements.in
     #   djangorestframework-simplejwt
     #   drf-yasg
-djangorestframework-simplejwt==4.5.0
+djangorestframework-simplejwt==5.3.1
     # via -r requirements.in
-drf-yasg[validation]==1.20.0
+drf-yasg[validation]==1.21.10
     # via -r requirements.in
 easyimap==0.7.0
     # via -r requirements.in
@@ -128,10 +126,6 @@ importlib-resources==6.4.5
     #   swagger-spec-validator
 inflection==0.5.1
     # via drf-yasg
-itypes==1.2.0
-    # via coreapi
-jinja2==3.1.6
-    # via coreschema
 jmespath==0.10.0
     # via
     #   boto3
@@ -146,8 +140,6 @@ lml==0.2.0
     # via
     #   pyexcel
     #   pyexcel-io
-markupsafe==2.1.5
-    # via jinja2
 numpy==1.24.4
     # via pandas
 packaging==25.0
@@ -195,25 +187,23 @@ python-magic==0.4.27
 python-stdnum==2.1
     # via django-localflavor
 pytz==2025.2
-    # via pandas
+    # via
+    #   drf-yasg
+    #   pandas
 pyyaml==6.0.2
-    # via swagger-spec-validator
+    # via
+    #   drf-yasg
+    #   swagger-spec-validator
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.4
-    # via
-    #   coreapi
-    #   django-anymail
+    # via django-anymail
 rpds-py==0.20.1
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.15
-    # via drf-yasg
-ruamel-yaml-clib==0.2.8
-    # via ruamel-yaml
 s3transfer==0.4.2
     # via boto3
 sentry-sdk==0.12.3
@@ -224,7 +214,6 @@ six==1.17.0
     #   bleach
     #   django-anymail
     #   django-autocomplete-light
-    #   django-extensions
     #   django-fancy-cache
     #   django-material
     #   python-dateutil
@@ -243,9 +232,7 @@ typing-extensions==4.13.2
     #   structlog
     #   swagger-spec-validator
 uritemplate==4.1.1
-    # via
-    #   coreapi
-    #   drf-yasg
+    # via drf-yasg
 urllib3==1.26.20
     # via
     #   botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,8 +56,6 @@ django==4.2.24
     #   jsonfield
 django-admin-row-actions==0.10.0
     # via -r requirements.in
-django-admincommand @ git+https://github.com/mgaitan/django-admincommand.git@filefield
-    # via -r requirements.in
 django-annoying==0.10.4
     # via -r requirements.in
 django-anymail==6.0.1
@@ -96,7 +94,7 @@ django-summernote==0.8.20.0
     # via -r requirements.in
 django-upload-validator==1.1.6
     # via -r requirements.in
-django-versatileimagefield==3.1
+django-versatileimagefield @ git+https://github.com/pdelboca/django-versatileimagefield@poc-auto-resize
     # via -r requirements.in
 djangoql==0.17.1
     # via -r requirements.in


### PR DESCRIPTION
This dependencies upgrades go me the runserver and migration working.

## Runserver

```
(escrutinio-social) ~/Repos/escrutinio-social/django_app  (update-dependencies) [10:29] $ runserver
/home/pdelboca/Repos/escrutinio-social/.venv/lib/python3.8/site-packages/material/__init__.py:19: UserWarning: The package was merged into django-viewflow. Please consider to switch to django-viewflow>=2.0.0b1
  warnings.warn("The package was merged into django-viewflow. Please consider to switch to django-viewflow>=2.0.0b1")
/home/pdelboca/Repos/escrutinio-social/.venv/lib/python3.8/site-packages/material/__init__.py:19: UserWarning: The package was merged into django-viewflow. Please consider to switch to django-viewflow>=2.0.0b1
  warnings.warn("The package was merged into django-viewflow. Please consider to switch to django-viewflow>=2.0.0b1")
2025-09-13 10:29:57,396 INFO [django.utils.autoreload:667] autoreload 11982 140499179525952 Watching for file changes with StatReloader
Performing system checks...

/home/pdelboca/Repos/escrutinio-social/.venv/lib/python3.8/site-packages/material/frontend/apps.py:89: UserWarning: Module contacto have not urls.py submodule or `urlpatterns` in it
  warnings.warn('Module {} have not urls.py submodule or `urlpatterns` in it'.format(self.label))
System check identified no issues (0 silenced).
September 13, 2025 - 10:29:57
Django version 4.2.24, using settings 'escrutinio_social.settings'
Starting development server at http://0.0.0.0:8000/
Quit the server with CONTROL-C.
```
### django-versatileimage

We were using a fork of this library that is no longer compatible with Django 4.2. Since the hack was quite straight forward I created a new fork from a Django 4.2 compatible version and apply the changes to it (with a small tweak).

**From:** https://github.com/respondcreate/django-versatileimagefield/compare/master...mgaitan:django-versatileimagefield:master
**To:** https://github.com/respondcreate/django-versatileimagefield/compare/master...pdelboca:django-versatileimagefield:poc-auto-resize

## Tests

```
================================== short test summary info ==================================
FAILED antitrolling/tests/test_efecto.py::test_diferencia_opciones - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
FAILED antitrolling/tests/test_efecto.py::test_diferencia_opciones_con_opciones_diferentes - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
FAILED antitrolling/tests/test_efecto.py::test_efecto_confirmar_carga_mesa_categoria - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
FAILED antitrolling/tests/test_efecto.py::test_efecto_ignora_cargas_incompatibles - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
FAILED antitrolling/tests/test_efecto.py::test_efecto_diferencia_1 - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
FAILED antitrolling/tests/test_integracion.py::test_confirmacion_carga_total_mesa_categoria_con_antitrolling - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
FAILED antitrolling/tests/test_integracion.py::test_carga_confirmada_troll_vuelve_a_sin_consolidar - assert -30 == -10
FAILED antitrolling/tests/test_integracion.py::test_cargas_troll_no_consolidadas - assert 0 == 20
FAILED api/tests/test_views.py::test_cargar_votos - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
FAILED elecciones/tests/test_proyecciones.py::test_proyeccion_con_agrupaciones_no_consideradas - TypeError: Cannot use QuerySet.first() on an unordered queryset performing aggregation. ...
FAILED fiscales/tests/test_carga_datos.py::test_detalle_mesa_categoria - django.core.exceptions.FieldError: Cannot resolve keyword 'orden' into field. Choices ar...
============ 11 failed, 467 passed, 2 skipped, 244 warnings in 213.95s (0:03:33) ============
```